### PR TITLE
Add streaming PUT/GET optimizations to KVServiceSM backend

### DIFF
--- a/lmc_external_kv_service_sm_backend/kv_service_sm_backend.py
+++ b/lmc_external_kv_service_sm_backend/kv_service_sm_backend.py
@@ -22,6 +22,7 @@ import asyncio
 import threading
 
 # Third Party
+from aiohttp import payload
 import aiohttp
 import torch
 
@@ -46,6 +47,30 @@ class LeaseInfo:
     lease_id: str
     offsets: List[Tuple[int, int]]  # (offset, length) pairs
     total_size: int
+
+
+class _KVStream(payload.Payload):
+    """Two-part streaming body: [metadata][payload memoryview].
+
+    Avoids concatenating multi-GB buffers into a single bytes object.
+    """
+
+    def __init__(self, meta: bytes, buf_mv: memoryview, chunk_bytes: int):
+        super().__init__(None)
+        self._meta = meta
+        self._buf = buf_mv
+        self._step = max(1, int(chunk_bytes))
+        # Expose size so aiohttp can set Content-Length (no chunked encoding)
+        self.size = len(self._meta) + len(self._buf)
+
+    async def write(self, writer):
+        # metadata is tiny; write at once
+        await writer.write(self._meta)
+        # stream payload in slices to avoid large Python copies
+        mv = self._buf
+        step = self._step
+        for i in range(0, len(mv), step):
+            await writer.write(mv[i : i + step])
 
 
 class KVServiceSMBackend(StorageBackendInterface):
@@ -97,6 +122,16 @@ class KVServiceSMBackend(StorageBackendInterface):
         self.release_timeout_ms = extra_config.get("kv_service_sm_release_timeout_ms", 2000)
 
         # Performance optimizations for scale
+        # Size of each write slice when streaming PUTs. 4–16MB are good defaults.
+        self.put_chunk_bytes = int(
+            extra_config.get("kv_service_sm_put_chunk_bytes", 8 * 1024 * 1024)
+        )
+
+        # Bounded deserialization pool for GET copies (keeps event loop free)
+        self.deserialization_threads = int(
+            extra_config.get("kv_service_sm_deserialization_threads", 16)
+        )
+
         self.max_connections = extra_config.get("kv_service_sm_max_connections", 256)
         self.max_connections_per_host = extra_config.get(
             "kv_service_sm_max_connections_per_host", 128
@@ -113,6 +148,12 @@ class KVServiceSMBackend(StorageBackendInterface):
         self.thread_pool = ThreadPoolExecutor(
             max_workers=self.serialization_threads,
             thread_name_prefix="kv-service-sm-serialize",
+        )
+
+        # Separate pool for GET reconstruction/copies
+        self.deser_pool = ThreadPoolExecutor(
+            max_workers=self.deserialization_threads,
+            thread_name_prefix="kv-service-sm-deser",
         )
 
         self.lease_lock = threading.Lock()
@@ -269,7 +310,7 @@ class KVServiceSMBackend(StorageBackendInterface):
 
     @_lmcache_nvtx_annotate
     async def _async_put(self, key: CacheEngineKey, memory_obj: MemoryObj) -> None:
-        """Optimized async PUT operation with thread pool for serialization and early memory release."""  # noqa: E501
+        """Async PUT with zero-copy(ish) streaming: send [meta][payload] without concatenation."""
         serialization_start = None
         http_start = None
         memory_released = False
@@ -288,17 +329,24 @@ class KVServiceSMBackend(StorageBackendInterface):
             key_str = self._key_to_string(store_key)
             url = f"{self.base_url}/v1/kv/{self.bucket_name}/{key_str}"
 
-            # OPTIMIZATION 1: Serialize tensor on thread pool (CPU-bound operation)
+            # Build *only* metadata bytes on the pool (tiny); DO NOT materialize [meta]+[payload]
             loop = asyncio.get_running_loop()
             serialization_start = loop.time()
-            data = await loop.run_in_executor(
-                self.thread_pool, self._memory_obj_to_bytes, memory_obj
+            meta_bytes = await loop.run_in_executor(
+                self.thread_pool, self._metadata_only_bytes, memory_obj
             )
             serialization_time = loop.time() - serialization_start
 
-            # OPTIMIZATION 2: Early memory release - tensor copied to bytes, release GPU memory  # noqa: E501
-            memory_obj.ref_count_down()
-            memory_released = True
+            # Prepare a *zero-copy view* over the existing payload buffer.
+            # We must keep memory_obj alive until the PUT finishes.
+            try:
+                buf_mv = memoryview(memory_obj.byte_array)
+            except TypeError:
+                # Fallback if allocator returned bytes-like but not buffer-protocol
+                buf_mv = memoryview(bytes(memory_obj.byte_array))
+
+            # Stream the HTTP body: [meta][payload] in slices; no giant concat.
+            data = _KVStream(meta_bytes, buf_mv, self.put_chunk_bytes)
 
             # HTTP request on event loop (I/O-bound operation)
             http_start = loop.time()
@@ -309,7 +357,7 @@ class KVServiceSMBackend(StorageBackendInterface):
 
             if result and result["status"] == 200:
                 logger.debug(
-                    f"Successfully stored key {key}: {len(data)} bytes, "
+                    f"Successfully stored key {key}: {len(meta_bytes) + len(buf_mv)} bytes, "
                     f"serialize: {serialization_time * 1000:.1f}ms, "
                     f"http: {http_time * 1000:.1f}ms"
                 )
@@ -318,13 +366,14 @@ class KVServiceSMBackend(StorageBackendInterface):
                 logger.error(f"Failed to store key {key}: HTTP {status}")
         except Exception as e:
             logger.exception(f"Exception during PUT for key {key}: {e}")
-            # Ensure memory is released even on error
+        finally:
+            # Now that the PUT completed/failed, safe to release the underlying buffer.
             if not memory_released:
                 try:
                     memory_obj.ref_count_down()
                 except Exception:
-                    pass  # May have already been released or failed for other reasons
-        finally:
+                    pass
+                memory_released = True
             # Always cleanup task tracking
             with self.put_lock:
                 self.put_tasks.discard(key)
@@ -373,8 +422,13 @@ class KVServiceSMBackend(StorageBackendInterface):
             return None
 
         try:
-            # Step 2: Read and reconstruct tensor from shared memory
-            result = await self._read_tensor_from_lease(key, lease_info)
+            # Step 2: Ensure SHM then reconstruct off the event loop (deser pool)
+            if not await self._ensure_shared_memory():
+                return None
+            loop = asyncio.get_running_loop()
+            result = await loop.run_in_executor(
+                self.deser_pool, self._materialize_from_lease_sync, key, lease_info
+            )
             return result
         finally:
             # Step 3: Always release lease
@@ -442,118 +496,76 @@ class KVServiceSMBackend(StorageBackendInterface):
 
         return success
 
-    async def _read_tensor_from_lease(
+    def _materialize_from_lease_sync(
         self, key: CacheEngineKey, lease_info: LeaseInfo
     ) -> Optional[MemoryObj]:
-        """Unified tensor reading from lease - handles both single and multi-block cases."""  # noqa: E501
-        if not await self._ensure_shared_memory():
+        """Single-pass SHM→dest copy (no intermediate concat). Runs in deser thread."""
+        if self.shared_memory_map is None:
             return None
-
         if not lease_info.offsets:
             logger.error(f"No offsets in lease for key {key}")
             return None
 
-        try:
-            # Read all data (single block is just multi-block with length=1)
-            total_data = bytearray()
-            # Ensure shared_memory_map is not None (guaranteed by _ensure_shared_memory check above)  # noqa: E501
-            if self.shared_memory_map is None:
-                logger.error(
-                    "Shared memory map is None despite successful initialization check"  # noqa: E501
-                )
-                return None
+        mv = self.shared_memory_map  # memoryview over SHM
 
-            for offset, length in lease_info.offsets:
-                chunk = bytes(self.shared_memory_map[offset : offset + length])
-                total_data.extend(chunk)
+        # --- 1) Read fixed-size header into tiny scratch ---
+        # RemoteMetadata header is 7 int32 fields; keep protocol in sync if it changes.
+        HEADER_BYTES = 4 * 7
+        hdr = bytearray(HEADER_BYTES)
+        filled = 0
+        for off, ln in lease_info.offsets:
+            if filled >= HEADER_BYTES:
+                break
+            n = min(ln, HEADER_BYTES - filled)
+            hdr[filled : filled + n] = mv[off : off + n]
+            filled += n
+        if filled < HEADER_BYTES:
+            logger.error("Insufficient data for metadata header")
+            return None
+        metadata = RemoteMetadata.deserialize(hdr)
 
-            # Validate total size
-            if len(total_data) != lease_info.total_size:
-                logger.error(
-                    f"Size mismatch: expected {lease_info.total_size}, got {len(total_data)}"  # noqa: E501
-                )
-                return None
-
-            # Parse simple format: [RemoteMetadata struct][byte_array]
-            metadata_size = 4 * 7  # RemoteMetadata is 7 integers
-            if len(total_data) < metadata_size:
-                logger.error("Insufficient data for metadata header")
-                return None
-
-            try:
-                # Parse using existing RemoteMetadata
-                metadata = RemoteMetadata.deserialize(total_data[:metadata_size])
-                kv_bytes = total_data[metadata_size : metadata_size + metadata.length]
-
-                if len(kv_bytes) != metadata.length:
-                    logger.error(
-                        f"Data size mismatch: expected {metadata.length}, "
-                        f"got {len(kv_bytes)}"
-                    )
-                    return None
-
-                # Simple reconstruction using existing allocator
-                return await self._create_simple_tensor_from_metadata(
-                    key, metadata, kv_bytes
-                )
-
-            except Exception as e:
-                logger.error(f"Failed to parse simple metadata: {e}")
-                return None
-
-        except Exception as e:
-            logger.error(f"Error reading tensor from lease for key {key}: {e}")
+        # --- 2) Allocate destination with actual shape/dtype/format ---
+        # RemoteMetadata stores 4D padded shape; remove trailing zeros
+        original_shape = metadata.shape
+        actual_shape_list: List[int] = []
+        for dim in original_shape:
+            if dim == 0 and len(actual_shape_list) > 0:
+                break
+            actual_shape_list.append(dim)
+        actual_shape = (
+            torch.Size(actual_shape_list) if actual_shape_list else torch.Size([1])
+        )
+        mem = self.memory_allocator.allocate(actual_shape, metadata.dtype, metadata.fmt)
+        if mem is None:
+            logger.error(f"Failed to allocate memory for key {key}")
             return None
 
-    async def _create_simple_tensor_from_metadata(
-        self, key: CacheEngineKey, metadata: RemoteMetadata, kv_bytes: bytes
-    ) -> Optional[MemoryObj]:
-        """Simple tensor reconstruction using Redis-style approach."""
-        try:
-            # RemoteMetadata uses 4D padded shape - restore original shape
-            # by removing trailing zeros
-            original_shape = metadata.shape
-            # Remove trailing zeros to get the actual shape
-            actual_shape_list: List[int] = []
-            for dim in original_shape:
-                if dim == 0 and len(actual_shape_list) > 0:
-                    # Stop at first zero after we have at least one dimension
-                    break
-                actual_shape_list.append(dim)
-
-            # Convert back to torch.Size
-            actual_shape = (
-                torch.Size(actual_shape_list) if actual_shape_list else torch.Size([1])
-            )
-
-            # Allocate memory object using existing allocator with actual shape
-            memory_obj = self.memory_allocator.allocate(
-                actual_shape, metadata.dtype, metadata.fmt
-            )
-            if memory_obj is None:
-                logger.error(f"Failed to allocate memory for key {key}")
-                return None
-
-            # Direct byte copy - no tensor conversion needed!
-            if isinstance(memory_obj.byte_array, memoryview):
-                view = memory_obj.byte_array
-                if view.format == "<B":
-                    view = view.cast("B")
-            else:
-                view = memoryview(memory_obj.byte_array)
-
-            # Copy data directly to byte array
-            view[: metadata.length] = kv_bytes
-
-            logger.debug(
-                f"Simple reconstruction: actual_shape={actual_shape}, "
-                f"dtype={metadata.dtype}, format={metadata.fmt}"
-            )
-            return memory_obj
-
-        except Exception as e:
-            logger.error(f"Error in simple tensor reconstruction for key {key}: {e}")
+        # --- 3) Copy payload once: SHM slices → destination view ---
+        dst = memoryview(mem.byte_array)[: metadata.length]
+        written, payload_skip = 0, HEADER_BYTES
+        for off, ln in lease_info.offsets:
+            if payload_skip:
+                if ln <= payload_skip:
+                    payload_skip -= ln
+                    continue
+                off += payload_skip
+                ln -= payload_skip
+                payload_skip = 0
+            if ln <= 0:
+                continue
+            n = min(ln, len(dst) - written)
+            dst[written : written + n] = mv[off : off + n]
+            written += n
+            if written == len(dst):
+                break
+        if written != len(dst):
+            logger.error(f"Size mismatch: expected {len(dst)}, wrote {written}")
             return None
+
+        logger.debug(
+            f"Reconstructed key={key} shape={actual_shape} dtype={metadata.dtype} fmt={metadata.fmt}"
+        )
+        return mem
 
     async def _ensure_shared_memory(self) -> bool:
         """Ensure shared memory is initialized and accessible."""
@@ -643,6 +655,14 @@ class KVServiceSMBackend(StorageBackendInterface):
             except Exception as e:
                 logger.error(f"Error shutting down thread pool: {e}")
 
+        # Shutdown deserialization pool
+        if self.deser_pool is not None:
+            try:
+                self.deser_pool.shutdown(wait=True)
+                logger.info("Deserialization thread pool shutdown complete")
+            except Exception as e:
+                logger.error(f"Error shutting down deserialization pool: {e}")
+
         # Note: No CUDA streams to cleanup in simple approach
 
         # Close shared memory resources
@@ -676,8 +696,33 @@ class KVServiceSMBackend(StorageBackendInterface):
 
         key_str = key.to_string()
         encoded_key = urllib.parse.quote(key_str, safe="")
-        
+
         return encoded_key
+
+    def _metadata_only_bytes(self, memory_obj: MemoryObj) -> bytes:
+        """Return just the RemoteMetadata header bytes (no payload).
+
+        Used by streaming PUT to avoid concatenating multi-GB payloads.
+        """
+
+        kv_shape = memory_obj.get_shape()
+        kv_dtype = memory_obj.get_dtype()
+        memory_format = memory_obj.get_memory_format()
+
+        # Compute payload length from current buffer view
+        try:
+            payload_len = len(memoryview(memory_obj.byte_array))
+        except TypeError:
+            payload_len = len(bytes(memory_obj.byte_array))
+
+        # RemoteMetadata expects 4D shape; pad/truncate accordingly
+        padded_shape = list(kv_shape) + [0] * (4 - len(kv_shape))
+        if len(padded_shape) > 4:
+            padded_shape = list(kv_shape[:4])
+        padded_torch_shape = torch.Size(padded_shape)
+
+        metadata = RemoteMetadata(payload_len, padded_torch_shape, kv_dtype, memory_format)
+        return metadata.serialize()
 
     def _memory_obj_to_bytes(self, memory_obj: MemoryObj) -> bytes:
         """Ultra-simple serialization using Redis-style approach.


### PR DESCRIPTION
## Summary
- stream PUT bodies by sending metadata and payload without concatenation via a custom aiohttp payload
- add configuration knobs for chunk sizes and GET deserialization threads and run GET reconstruction on a dedicated pool
- materialize GET results with a single shared-memory to destination copy and cleanly shut down the new resources

## Testing
- python -m compileall lmc_external_kv_service_sm_backend

------
https://chatgpt.com/codex/tasks/task_e_68d072155c088330a3f42a2c75fd9a6d